### PR TITLE
Make FB failures more safe

### DIFF
--- a/lib/pismo/server.rb
+++ b/lib/pismo/server.rb
@@ -80,12 +80,11 @@ module Pismo
           client_secret: Pismo::Configuration.options[:fb_secret],
           grant_type: 'client_credentials'
         }
-        access_token = open("#{FB_GET_TOKEN_URL}?#{access_params.to_query}").read
-
-        unencoded_url = "#{FB_API_URL}#{vid}?#{access_token}"
-        request_url = URI.encode unencoded_url
         data =
           begin
+            access_token = open("#{FB_GET_TOKEN_URL}?#{access_params.to_query}").read
+            unencoded_url = "#{FB_API_URL}#{vid}?#{access_token}"
+            request_url = URI.encode unencoded_url
             resp = JSON.parse open(request_url, "User-Agent" => "MashableBot").read
           rescue
             {}


### PR DESCRIPTION
`access_token = open("#{FB_GET_TOKEN_URL}?#{access_params.to_query}").read` is currently [400'ing on production](https://rpm.newrelic.com/accounts/30019/applications/1135420/filterable_errors#/show/115347-08bdf86f-e7b6-11e5-ac23-f8bc124250a8/stack_trace?top_facet=transactionUiName&primary_facet=error.class&barchart=barchart&filters=%5B%7B%22key%22%3A%22error.class%22%2C%22value%22%3A%22OpenURI%3A%3AHTTPError%22%2C%22like%22%3Afalse%7D%5D&_k=5f5rc9).

`curl https://graph.facebook.com/v2.0/` from the webheads yields:

```
{"error":{"message":"(#4) Application request limit reached","type":"OAuthException","is_transient":true,"code":4,"fbtrace_id":"C6RLlY+GQ7J"}}
```

In the interim, this should probably serve to isolate non-FB requests from error, though I don't know if there are dependencies such that a FB auth error _must_ cascade-fail.
